### PR TITLE
Implement paged memory

### DIFF
--- a/duna_macro/src/lib.rs
+++ b/duna_macro/src/lib.rs
@@ -178,7 +178,7 @@ fn impl_itype_load_derive(ast: &syn::DeriveInput) -> TokenStream {
             ) -> UserDiff<RiscV<T>, T> {
                 let rs1_val: T::Signed = state.regfile.read(rs1).into();
                 let addr: T::RegData = (rs1_val + imm.into()).into();
-                let new_rd_val = <#name as ITypeLoad<T>>::eval(&state.memory, addr.into());
+                let new_rd_val = <#name as ITypeLoad<T>>::eval(state.memory.as_ref(), addr.into());
                 UserDiff::reg_write_pc_p4(state, rd, new_rd_val)
             }
         }

--- a/src/architectures/riscv/instruction.rs
+++ b/src/architectures/riscv/instruction.rs
@@ -255,7 +255,7 @@ pub(crate) trait ITypeArith<T: MachineDataWidth>: IType<T> {
 pub(crate) trait ITypeLoad<T: MachineDataWidth>: IType<T> {
     fn inst_fields() -> IInstFields;
     fn eval(
-        mem: &Box<dyn Memory<T::ByteAddr>>,
+        mem: &dyn Memory<T::ByteAddr>,
         addr: <T as MachineDataWidth>::ByteAddr,
     ) -> <T as MachineDataWidth>::RegData;
 }

--- a/src/architectures/riscv/instruction.rs
+++ b/src/architectures/riscv/instruction.rs
@@ -255,7 +255,7 @@ pub(crate) trait ITypeArith<T: MachineDataWidth>: IType<T> {
 pub(crate) trait ITypeLoad<T: MachineDataWidth>: IType<T> {
     fn inst_fields() -> IInstFields;
     fn eval(
-        mem: &Memory<T>,
+        mem: &Box<dyn Memory<T::ByteAddr>>,
         addr: <T as MachineDataWidth>::ByteAddr,
     ) -> <T as MachineDataWidth>::RegData;
 }

--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -273,7 +273,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lb {
         }
     }
 
-    fn eval(mem: &Box<dyn Memory<T::ByteAddr>>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T::ByteAddr>, addr: T::ByteAddr) -> T::RegData {
         <T::RegData>::sign_ext_from_byte(mem.get_byte(addr).unwrap())
     }
 }
@@ -288,7 +288,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lbu {
         }
     }
 
-    fn eval(mem: &Box<dyn Memory<T::ByteAddr>>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T::ByteAddr>, addr: T::ByteAddr) -> T::RegData {
         <T::RegData>::zero_pad_from_byte(mem.get_byte(addr).unwrap())
     }
 }
@@ -304,7 +304,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lh {
     }
 
     // TODO define alignment behavior
-    fn eval(mem: &Box<dyn Memory<T::ByteAddr>>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T::ByteAddr>, addr: T::ByteAddr) -> T::RegData {
         let og_addr: T::Signed = addr.into();
         let second_byte_addr: T::ByteAddr = (og_addr.wrapping_add(&T::sgn_one())).into();
         let upper_byte: T::Signed =
@@ -326,7 +326,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lhu {
     }
 
     // TODO define alignment behavior
-    fn eval(mem: &Box<dyn Memory<T::ByteAddr>>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T::ByteAddr>, addr: T::ByteAddr) -> T::RegData {
         let og_addr: T::Signed = addr.into();
         let second_byte_addr: T::ByteAddr = (og_addr.wrapping_add(&T::sgn_one())).into();
         let upper_byte: T::Signed =
@@ -366,7 +366,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lw {
     }
 
     // TODO define alignment behavior
-    fn eval(mem: &Box<dyn Memory<T::ByteAddr>>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T::ByteAddr>, addr: T::ByteAddr) -> T::RegData {
         <T::RegData>::sign_ext_from_word(mem.get_word(addr).unwrap())
     }
 }

--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -273,7 +273,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lb {
         }
     }
 
-    fn eval(mem: &Memory<T>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T>, addr: T::ByteAddr) -> T::RegData {
         <T::RegData>::sign_ext_from_byte(mem.get_byte(addr))
     }
 }
@@ -288,7 +288,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lbu {
         }
     }
 
-    fn eval(mem: &Memory<T>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T>, addr: T::ByteAddr) -> T::RegData {
         <T::RegData>::zero_pad_from_byte(mem.get_byte(addr))
     }
 }
@@ -304,7 +304,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lh {
     }
 
     // TODO define alignment behavior
-    fn eval(mem: &Memory<T>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T>, addr: T::ByteAddr) -> T::RegData {
         let og_addr: T::Signed = addr.into();
         let second_byte_addr: T::ByteAddr = (og_addr.wrapping_add(&T::sgn_one())).into();
         let upper_byte: T::Signed =
@@ -325,7 +325,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lhu {
     }
 
     // TODO define alignment behavior
-    fn eval(mem: &Memory<T>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T>, addr: T::ByteAddr) -> T::RegData {
         let og_addr: T::Signed = addr.into();
         let second_byte_addr: T::ByteAddr = (og_addr.wrapping_add(&T::sgn_one())).into();
         let upper_byte: T::Signed =
@@ -364,7 +364,7 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lw {
     }
 
     // TODO define alignment behavior
-    fn eval(mem: &Memory<T>, addr: T::ByteAddr) -> T::RegData {
+    fn eval(mem: &dyn Memory<T>, addr: T::ByteAddr) -> T::RegData {
         <T::RegData>::sign_ext_from_word(mem.get_word(addr.to_word_address()))
     }
 }

--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -389,7 +389,7 @@ impl<T: MachineDataWidth> SType<T> for Sb {
         let base_addr: T::Signed = state.regfile.read(rs1).into();
         let byte_addr: T::ByteAddr = (base_addr.wrapping_add(&imm.into())).into();
         let new_byte = state.regfile.read(rs2).get_byte(0);
-        UserDiff::mem_write_op(state, byte_addr, DataEnum::Byte(DataByte::from(new_byte))).unwrap()
+        UserDiff::mem_write_op(state, byte_addr, DataEnum::Byte(new_byte)).unwrap()
     }
 }
 

--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -792,13 +792,15 @@ mod test {
     #[test]
     fn test_ecall() {
         let mut state = get_init_state();
+        state.regfile_set(SP, 0x7FFF_000.into());
         let addr = ByteAddr32::from(state.regfile_read(SP));
         state.memory_set_word(addr, DataWord::from(0xDEAD_BEEFu32));
         // Set ecall code
         state.regfile_set(
             A7,
             RiscVSyscallConvention::<Width32b>::syscall_to_number(Syscall::Write),
-        ); // We're writing 4 bytes to stdout, which has fd 1
+        );
+        // We're writing 4 bytes to stdout, which has fd 1
         state.regfile_set(A0, DataWord::from(1));
         state.regfile_set(A1, DataWord::from(addr));
         state.regfile_set(A2, DataWord::from(4));

--- a/src/architectures/riscv/program.rs
+++ b/src/architectures/riscv/program.rs
@@ -103,7 +103,7 @@ impl str::FromStr for RiscVProgram<Width32b> {
     type Err = ParseErrorReport;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Linker::with_main_str(s).link::<RV32>()
+        Linker::with_main_str(s).link::<RV32>(Default::default())
     }
 }
 

--- a/src/assembler/assembler_impl.rs
+++ b/src/assembler/assembler_impl.rs
@@ -3,7 +3,7 @@ use super::parse_error::{ParseError, ParseErrorReporter};
 use super::parser::{Label, LabelRef, ParseResult, Parser};
 use super::partial_inst::{PartialInst, PartialInstType};
 use crate::arch::*;
-use crate::program_state::Program;
+use crate::program_state::{Program, SimpleMemory};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
@@ -218,8 +218,13 @@ impl<S: Architecture> UnlinkedProgram<S> {
                 },
             )
             .collect();
+        // TODO expose memory configuration
         if reporter.is_empty() {
-            Ok(<S::Program>::new(insts, self.sections))
+            Ok(<S::Program>::new(
+                insts,
+                self.sections,
+                Box::new(SimpleMemory::new()),
+            ))
         } else {
             Err(reporter)
         }
@@ -234,6 +239,7 @@ impl<S: Architecture> UnlinkedProgram<S> {
                 .map(|(_, partial_inst)| partial_inst.try_into_concrete_inst())
                 .collect(),
             self.sections,
+            Box::new(SimpleMemory::new()),
         )
     }
 }

--- a/src/assembler/linker.rs
+++ b/src/assembler/linker.rs
@@ -3,6 +3,7 @@ use super::datatypes::*;
 use super::parse_error::{ParseError, ParseErrorReport, ParseErrorReporter};
 use super::parser::{Label, LabelDef};
 use crate::arch::*;
+use crate::config::*;
 use std::collections::HashMap;
 use std::fs;
 
@@ -63,7 +64,7 @@ impl Linker {
     }
 
     /// Attempts to link the provided programs together into a single executable.
-    pub fn link<S: Architecture>(self) -> Result<S::Program, ParseErrorReport> {
+    pub fn link<S: Architecture>(self, config: AsmConfig) -> Result<S::Program, ParseErrorReport> {
         assert!(
             !self.file_map.is_empty(),
             "Linker is missing a main program"
@@ -121,7 +122,7 @@ impl Linker {
             if errs.is_empty() {
                 // handles errantly undefined labels, although they should've already been caught
                 linked
-                    .into_program()
+                    .into_program(&config.machine)
                     .map_err(|r| r.into_report_with_file_map(self.file_map))
             } else {
                 // handles undeclared labels

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,72 @@
+use crate::program_state::*;
+
+/// Options for the assembler.
+#[derive(Debug)]
+pub struct AsmConfig {
+    /// Parameters for the machine being emulated.
+    pub machine: MachineConfig,
+}
+
+impl Default for AsmConfig {
+    fn default() -> Self {
+        AsmConfig {
+            machine: Default::default(),
+        }
+    }
+}
+
+/// Configuration for the machine being emulated.
+#[derive(Debug)]
+pub struct MachineConfig {
+    pub mem_config: MemConfig,
+}
+
+impl Default for MachineConfig {
+    fn default() -> Self {
+        MachineConfig {
+            mem_config: Default::default(),
+        }
+    }
+}
+
+/// Configures a memory device.
+/// TODO add options for alignment and default value
+#[derive(Debug)]
+pub struct MemConfig {
+    pub kind: MemKind,
+}
+
+impl Default for MemConfig {
+    fn default() -> Self {
+        MemConfig {
+            // 4 KiB page size, 4 MiB physical memory
+            kind: MemKind::LinearPaged {
+                phys_addr_len: 22,
+                page_offs_len: 12,
+            },
+        }
+    }
+}
+
+impl MemConfig {
+    pub fn build_mem<T: ByteAddress>(&self) -> Box<dyn Memory<T>> {
+        use crate::program_state::*;
+        let kind = self.kind;
+        match kind {
+            MemKind::Simple => Box::new(SimpleMemory::<T>::new()),
+            MemKind::LinearPaged {
+                phys_addr_len,
+                page_offs_len,
+            } => Box::new(LinearPagedMemory::<T>::new(phys_addr_len, page_offs_len)),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum MemKind {
+    Simple,
+    LinearPaged {
+        phys_addr_len: usize,
+        page_offs_len: usize,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@ extern crate num_traits;
 pub mod arch;
 pub mod architectures;
 pub mod assembler;
+pub mod config;
 pub mod instruction;
 pub mod program_state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     for file in file_names {
         linker = linker.with_file(file);
     }
-    let link_result = linker.link::<RV32>();
+    let link_result = linker.link::<RV32>(Default::default());
     let mut program = match link_result {
         Ok(p) => p,
         Err(errs) => {

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -425,7 +425,7 @@ impl From<DataByte> for i8 {
     }
 }
 
-pub trait ByteAddress: Clone + Copy + fmt::Debug + 'static {
+pub trait ByteAddress: Clone + Copy + Sized + fmt::Debug + 'static {
     type WordAddress: Hash + Eq + Copy + Clone;
 
     /// Gets the number of bits in this address type.
@@ -438,13 +438,9 @@ pub trait ByteAddress: Clone + Copy + fmt::Debug + 'static {
 
     fn get_word_offset(self) -> u8;
 
-    fn plus_4(self) -> Self
-    where
-        Self: Sized;
+    fn plus_4(self) -> Self;
 
-    fn plus_1(self) -> Self
-    where
-        Self: Sized;
+    fn plus_1(self) -> Self;
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, ConvertInt64)]

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -447,9 +447,9 @@ pub trait ByteAddress: Clone + Copy + Sized + fmt::Debug + 'static {
         let bits = self.bits();
         match width {
             DataWidth::Byte => true,
-            DataWidth::Half => bits & 0b1 == 0,
-            DataWidth::Word => bits & 0b11 == 0,
-            DataWidth::DoubleWord => bits & 0b111 == 0,
+            DataWidth::Half => bits % 2 == 0,
+            DataWidth::Word => bits % 4 == 0,
+            DataWidth::DoubleWord => bits % 8 == 0,
         }
     }
 }

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -112,9 +112,29 @@ pub enum DataWidth {
     DoubleWord,
 }
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum DataEnum {
+    Byte(DataByte),
+    Half(DataHalf),
+    Word(DataWord),
+    DoubleWord(DataDword),
+}
+
+impl DataEnum {
+    pub fn width(self) -> DataWidth {
+        match self {
+            DataEnum::Byte(_) => DataWidth::Byte,
+            DataEnum::Half(_) => DataWidth::Half,
+            DataEnum::Word(_) => DataWidth::Word,
+            DataEnum::DoubleWord(_) => DataWidth::DoubleWord,
+        }
+    }
+}
+
 /// Marker trait for different datatypes.
 pub trait Data: Copy + Clone + PartialEq {
-    fn kind(self) -> DataWidth;
+    fn kind(self) -> DataEnum;
+    fn width(self) -> DataWidth;
 }
 
 /// Represents a 64-bit double-word of data.
@@ -124,7 +144,11 @@ pub struct DataDword {
 }
 
 impl Data for DataDword {
-    fn kind(self) -> DataWidth {
+    fn kind(self) -> DataEnum {
+        DataEnum::DoubleWord(self)
+    }
+
+    fn width(self) -> DataWidth {
         DataWidth::DoubleWord
     }
 }
@@ -222,7 +246,11 @@ pub struct DataWord {
 }
 
 impl Data for DataWord {
-    fn kind(self) -> DataWidth {
+    fn kind(self) -> DataEnum {
+        DataEnum::Word(self)
+    }
+
+    fn width(self) -> DataWidth {
         DataWidth::Word
     }
 }
@@ -317,7 +345,11 @@ pub struct DataHalf {
 }
 
 impl Data for DataHalf {
-    fn kind(self) -> DataWidth {
+    fn kind(self) -> DataEnum {
+        DataEnum::Half(self)
+    }
+
+    fn width(self) -> DataWidth {
         DataWidth::Half
     }
 }
@@ -354,7 +386,11 @@ pub struct DataByte {
 }
 
 impl Data for DataByte {
-    fn kind(self) -> DataWidth {
+    fn kind(self) -> DataEnum {
+        DataEnum::Byte(self)
+    }
+
+    fn width(self) -> DataWidth {
         DataWidth::Byte
     }
 }

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -441,6 +441,17 @@ pub trait ByteAddress: Clone + Copy + Sized + fmt::Debug + 'static {
     fn plus_4(self) -> Self;
 
     fn plus_1(self) -> Self;
+
+    /// Checks the alignment of the address.
+    fn is_aligned_to(self, width: DataWidth) -> bool {
+        let bits = self.bits();
+        match width {
+            DataWidth::Byte => true,
+            DataWidth::Half => bits & 0b1 == 0,
+            DataWidth::Word => bits & 0b11 == 0,
+            DataWidth::DoubleWord => bits & 0b111 == 0,
+        }
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone, ConvertInt64)]

--- a/src/program_state/memory.rs
+++ b/src/program_state/memory.rs
@@ -1,45 +1,342 @@
 use super::datatypes::*;
 use crate::arch::*;
 use std::collections::HashMap;
+use std::marker::PhantomData;
 
-pub struct Memory<T: MachineDataWidth> {
-    store: HashMap<<T::ByteAddr as ByteAddress>::WordAddress, DataWord>,
+#[derive(Debug)]
+pub struct PageFault<T: ByteAddress> {
+    user_vaddr: T,
 }
 
-impl<T: MachineDataWidth> Memory<T> {
-    pub(in crate::program_state) fn new() -> Memory<T> {
-        Memory {
+impl<T: ByteAddress> PageFault<T> {
+    /// Indicates a pagefault at the provided address.
+    pub fn at_addr(user_vaddr: T) -> Self {
+        PageFault { user_vaddr }
+    }
+}
+
+/// Trait to define a virtual memory abstraction.
+///
+/// All direct memory operations are byte-addressed; behavior for unaligned accesses is left up to
+/// the implementor.
+///
+/// Read operations will return either the requested data or a PageFault.
+/// Write operations will return a result with an empty value or a PageFault.
+pub trait Memory<T: ByteAddress> {
+    /// Checks whether the provided virtual address is mapped.
+    fn is_mapped(&self, addr: T) -> bool;
+    /// Faults if the page is unmapped.
+    fn fault_if_unmapped(&self, addr: T) -> Result<(), PageFault<T>>;
+    /// Maps a page to physical memory if it is not already mapped. Returns a reference to the page.
+    fn map_page(&self, vpn: VirtPN) -> Option<&MemPage>;
+
+    /// Stores an 8-bit byte to memory.
+    fn set_byte(&mut self, addr: T, value: DataByte) -> Result<(), PageFault<T>>;
+    /// Reads an 8-bit byte from memory.
+    fn get_byte(&self, addr: T) -> Result<DataByte, PageFault<T>>;
+    /// Stores a 16-bit halfword to memory.
+    fn set_half(&mut self, addr: T, value: DataHalf) -> Result<(), PageFault<T>>;
+    /// Reads a 16-bit halfword from memory.
+    fn get_half(&self, addr: T) -> Result<DataHalf, PageFault<T>>;
+    /// Stores a 32-bit word to memory.
+    fn set_word(&mut self, addr: T, value: DataWord) -> Result<(), PageFault<T>>;
+    /// Reads a 32-bit word from memory.
+    fn get_word(&self, addr: T) -> Result<DataWord, PageFault<T>>;
+    /// Stores a double word to memory.
+    fn set_doubleword(&mut self, addr: T, value: DataDword) -> Result<(), PageFault<T>>;
+    /// Reads a double word from memory.
+    fn get_doubleword(&self, addr: T) -> Result<DataDword, PageFault<T>>;
+}
+
+/// A simple memory backed by a word-addressed hashmap.
+/// Never pagefaults. Reads to uninitialized addresses always return 0.
+pub struct SimpleMemory<T: ByteAddress> {
+    store: HashMap<<T as ByteAddress>::WordAddress, DataWord>,
+}
+
+impl<T: ByteAddress> SimpleMemory<T> {
+    pub fn new() -> SimpleMemory<T> {
+        SimpleMemory {
             store: HashMap::new(),
         }
     }
+}
 
-    #[allow(dead_code)]
-    pub fn set_byte(&mut self, addr: T::ByteAddr, value: DataByte) {
-        let word_addr = addr.to_word_address();
+impl<T: ByteAddress> Memory<T> for SimpleMemory<T> {
+    fn is_mapped(&self, addr: T) -> bool {
+        true
+    }
+
+    fn fault_if_unmapped(&self, addr: T) -> Result<(), PageFault<T>> {
+        Ok(())
+    }
+
+    fn map_page(&self, vpn: VirtPN) -> Option<&MemPage> {
+        None
+    }
+
+    fn set_byte(&mut self, addr: T, value: DataByte) -> Result<(), PageFault<T>> {
         let offs = addr.get_word_offset();
-        let word_val = if let Some(&old_val) = self.store.get(&word_addr) {
+        let word_val = if let Some(&old_val) = self.store.get(&addr.to_word_address()) {
             old_val
         } else {
             DataWord::zero()
         };
-        self.set_word(word_addr, word_val.set_byte(offs, value))
+        self.set_word(addr, word_val.set_byte(offs, value))
     }
 
-    pub fn get_byte(&self, addr: T::ByteAddr) -> DataByte {
-        let word_addr = addr.to_word_address();
+    fn get_byte(&self, addr: T) -> Result<DataByte, PageFault<T>> {
         let offs = addr.get_word_offset();
-        self.get_word(word_addr).get_byte(offs)
+        Ok(self.get_word(addr)?.get_byte(offs))
     }
 
-    pub fn set_word(&mut self, addr: <T::ByteAddr as ByteAddress>::WordAddress, value: DataWord) {
-        self.store.insert(addr, value);
+    fn set_half(&mut self, addr: T, value: DataHalf) -> Result<(), PageFault<T>> {
+        let n: u16 = value.into();
+        self.set_byte(addr, (n as u8).into())?;
+        self.set_byte(addr.plus_1(), ((n >> 8) as u8).into())?;
+        Ok(())
     }
 
-    pub fn get_word(&self, addr: <T::ByteAddr as ByteAddress>::WordAddress) -> DataWord {
-        if let Some(&v) = self.store.get(&addr) {
+    fn get_half(&self, addr: T) -> Result<DataHalf, PageFault<T>> {
+        let lower: u8 = self.get_byte(addr)?.into();
+        let upper: u8 = self.get_byte(addr.plus_1())?.into();
+        Ok(DataHalf::from(
+            ((upper as u16) << 8) as u16 | (lower as u16),
+        ))
+    }
+
+    fn set_word(&mut self, addr: T, value: DataWord) -> Result<(), PageFault<T>> {
+        self.store.insert(addr.to_word_address(), value);
+        Ok(())
+    }
+
+    fn get_word(&self, addr: T) -> Result<DataWord, PageFault<T>> {
+        Ok(if let Some(&v) = self.store.get(&addr.to_word_address()) {
             v
         } else {
             DataWord::zero()
+        })
+    }
+
+    fn set_doubleword(&mut self, addr: T, value: DataDword) -> Result<(), PageFault<T>> {
+        let lower_word_addr = addr.to_word_address();
+        let upper_word_addr = addr.plus_4().to_word_address();
+        let upper_value = value.get_upper_word();
+        let lower_value = value.get_lower_word();
+        self.store.insert(upper_word_addr, upper_value);
+        self.store.insert(lower_word_addr, lower_value);
+        Ok(())
+    }
+
+    fn get_doubleword(&self, addr: T) -> Result<DataDword, PageFault<T>> {
+        let lower_word_addr = addr.to_word_address();
+        let upper_word_addr = addr.plus_4().to_word_address();
+        let upper_value = self
+            .store
+            .get(&upper_word_addr)
+            .unwrap_or(&DataWord::from(0));
+        let lower_value = self
+            .store
+            .get(&lower_word_addr)
+            .unwrap_or(&DataWord::from(0));
+        Ok(DataDword::from_words(*lower_value, *upper_value))
+    }
+}
+
+type VirtPN = usize;
+type PhysPN = usize;
+type PageOffset = usize;
+
+/// Maps a virtual page to a physical one.
+struct PTEntry {
+    /// The virtual page number.
+    pub vpn: VirtPN,
+    /// The physical page number.
+    pub ppn: PhysPN,
+}
+
+/// Represents a page of memory.
+/// TODO implement default value
+struct MemPage {
+    /// To ensure the simulator doesn't waste space allocating the full size of the page,
+    /// this backing store allocates bytes lazily.
+    /// TODO do something more efficient like a u64
+    backing: HashMap<PageOffset, DataByte>,
+}
+
+impl MemPage {
+    fn new() -> MemPage {
+        MemPage {
+            backing: HashMap::new(),
         }
+    }
+
+    fn set_byte(&mut self, offs: PageOffset, value: DataByte) {
+        self.backing.insert(offs, value);
+    }
+
+    fn get_byte(&self, offs: PageOffset) -> DataByte {
+        if let Some(v) = self.backing.get(&offs) {
+            *v
+        } else {
+            let default_value = DataByte::from(0u8);
+            self.backing.insert(offs, default_value);
+            default_value
+        }
+    }
+}
+
+/// A memory backed by a fully associative LRU linear page table.
+pub struct LinearPagedMemory<T: ByteAddress> {
+    phys_addr_len: usize,
+    page_offs_len: usize,
+    page_count: usize,
+    page_table: Vec<PTEntry>,
+    phys_mem: HashMap<PhysPN, MemPage>,
+    paged_out: HashMap<VirtPN, MemPage>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: ByteAddress> LinearPagedMemory<T> {
+    /// Initializes the memory. The number of pages is computed from the physical address and
+    /// page sizes.
+    /// * phys_addr_len: The number of bits in a physical address. The number of bytes of available
+    ///                  physical memory is given by 2 to the power of this number.
+    /// * page_offs_len: The number of bits needed to index a page. The number of bytes in a page is
+    ///                  likewise 2 to the power of this number.
+    pub fn new(phys_addr_len: usize, page_offs_len: usize) -> Self {
+        // TODO add assertions on page table parameters to ensure nothing is invalid
+        let page_count = 1 << (phys_addr_len - page_offs_len);
+        LinearPagedMemory {
+            phys_addr_len,
+            page_offs_len,
+            page_count: page_count,
+            page_table: Vec::with_capacity(page_count),
+            phys_mem: HashMap::new(),
+            paged_out: HashMap::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    fn split_addr(&self, addr: T) -> (VirtPN, PageOffset) {
+        // the page offset comes from the lower page_offs_len bits
+        // the vpn is the rest
+        let bits = addr.bits();
+        let lsb_mask = !((-1i64 as u64) << self.page_offs_len);
+        (
+            (bits >> self.page_offs_len) as usize,
+            (bits & lsb_mask) as usize,
+        )
+    }
+
+    fn lowest_free_ppn(&self) -> Option<PhysPN> {
+        for i in 0..self.page_count {
+            if !self.page_table.iter().any(|&e| e.ppn == i) {
+                return Some(i);
+            }
+        }
+        None
+    }
+}
+
+impl<T: ByteAddress> Memory<T> for LinearPagedMemory<T> {
+    /// Checks whether the provided virtual address is mapped.
+    fn is_mapped(&self, addr: T) -> bool {
+        let (vpn, _) = self.split_addr(addr);
+        self.page_table.iter().any(|&e| e.vpn == vpn)
+    }
+
+    fn fault_if_unmapped(&self, addr: T) -> Result<(), PageFault<T>> {
+        if self.is_mapped(addr) {
+            Ok(())
+        } else {
+            Err(PageFault::at_addr(addr))
+        }
+    }
+
+    /// Maps a page to memory if it is not already mapped, evicting other pages if necessary.
+    /// Since we're following an LRU policy, this page is placed at the front of the vec, which
+    /// we couldn't do if we were an actual OS but we're not so who cares.
+    /// Returns the page, or None on failure.
+    fn map_page(&self, vpn: VirtPN) -> Option<&MemPage> {
+        let page_table = &mut self.page_table;
+        Some(
+            if let Some(idx) = page_table.iter().position(|&e| e.vpn == vpn) {
+                // check if page already mapped
+                // remove and move to front of vec
+                let e = page_table.remove(idx);
+                page_table.insert(0, e);
+                self.phys_mem.get(&e.ppn).unwrap()
+            } else {
+                // create new entry
+                // check if eviction is needed
+                if page_table.len() == self.page_count {
+                    let evicted = page_table.pop().unwrap();
+                    self.paged_out
+                        .insert(evicted.vpn, self.phys_mem.remove(&evicted.ppn).unwrap());
+                }
+                // check if entry was previously paged out
+                let page = self.paged_out.remove(&vpn).unwrap_or(MemPage::new());
+                // get a new ppn
+                let ppn = self.lowest_free_ppn().unwrap();
+                let e = PTEntry { vpn, ppn };
+                page_table.insert(0, e);
+                self.phys_mem.insert(ppn, page);
+                self.phys_mem.get(&ppn).unwrap()
+            },
+        )
+    }
+
+    fn set_byte(&mut self, addr: T, value: DataByte) -> Result<(), PageFault<T>> {
+        self.fault_if_unmapped(addr)?;
+        let (vpn, offs) = self.split_addr(addr);
+        self.map_page(vpn).unwrap().set_byte(offs, value);
+        Ok(())
+    }
+
+    fn get_byte(&self, addr: T) -> Result<DataByte, PageFault<T>> {
+        self.fault_if_unmapped(addr)?;
+        let (vpn, offs) = self.split_addr(addr);
+        Ok(self.map_page(vpn).unwrap().get_byte(offs))
+    }
+
+    fn set_half(&mut self, addr: T, value: DataHalf) -> Result<(), PageFault<T>> {
+        // set lsb, then msb
+        self.set_byte(addr, (u16::from(value) as u8).into())?;
+        self.set_byte(addr.plus_1(), ((u16::from(value) >> 8) as u8).into())
+    }
+
+    fn get_half(&self, addr: T) -> Result<DataHalf, PageFault<T>> {
+        let lsb: u8 = self.get_byte(addr)?.into();
+        let msb: u8 = self.get_byte(addr.plus_1())?.into();
+        let full = ((msb as u16) << 8) | (lsb as u16);
+        Ok(DataHalf::from(full))
+    }
+
+    fn set_word(&mut self, addr: T, value: DataWord) -> Result<(), PageFault<T>> {
+        self.set_half(addr, (u32::from(value) as u16).into())?;
+        self.set_half(
+            addr.plus_1().plus_1(),
+            ((u32::from(value) >> 16) as u16).into(),
+        )
+    }
+
+    fn get_word(&self, addr: T) -> Result<DataWord, PageFault<T>> {
+        let lsb: u16 = self.get_half(addr)?.into();
+        let msb: u16 = self.get_half(addr.plus_1().plus_1())?.into();
+        let full = ((msb as u32) << 16) | (lsb as u32);
+        Ok(DataWord::from(full))
+    }
+
+    fn set_doubleword(&mut self, addr: T, value: DataDword) -> Result<(), PageFault<T>> {
+        self.set_word(addr, (u64::from(value) as u32).into())?;
+        self.set_word(addr.plus_4(), ((u64::from(value) >> 32) as u32).into())
+    }
+
+    fn get_doubleword(&self, addr: T) -> Result<DataDword, PageFault<T>> {
+        let lsb: u32 = self.get_word(addr)?.into();
+        let msb: u32 = self.get_word(addr.plus_4())?.into();
+        let full = ((msb as u64) << 32) | (lsb as u64);
+        Ok(DataDword::from(full))
     }
 }

--- a/src/program_state/mod.rs
+++ b/src/program_state/mod.rs
@@ -4,6 +4,6 @@ mod program;
 mod registers;
 
 pub use datatypes::*;
-pub use memory::{Memory, SimpleMemory};
+pub use memory::*;
 pub use program::*;
 pub use registers::IRegister;

--- a/src/program_state/mod.rs
+++ b/src/program_state/mod.rs
@@ -4,6 +4,6 @@ mod program;
 mod registers;
 
 pub use datatypes::*;
-pub use memory::Memory;
+pub use memory::{Memory, SimpleMemory};
 pub use program::*;
 pub use registers::IRegister;

--- a/src/program_state/program.rs
+++ b/src/program_state/program.rs
@@ -451,7 +451,7 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> UserDiff<F, T> {
         state: &UserProgState<F, T>,
         addr: T::ByteAddr,
         val: DataEnum,
-    ) -> Result<Self, PageFault<T::ByteAddr>> {
+    ) -> Result<Self, MemFault<T::ByteAddr>> {
         Ok(UserDiff::new_pc_p4(
             state,
             None,

--- a/tests/rv32.rs
+++ b/tests/rv32.rs
@@ -14,7 +14,7 @@ fn get_full_test_path(relative_path: &str) -> String {
 
 fn program_from_file(filename: &str) -> RiscVProgram<Width32b> {
     let program: RiscVProgram<Width32b> = Linker::with_main(&get_full_test_path(filename))
-        .link::<RV32>()
+        .link::<RV32>(Default::default())
         .unwrap();
     // stdout is suppressed unless a test fails
     program.dump_insts();
@@ -27,7 +27,7 @@ fn err_report_from_files(main_filename: &str, others: Vec<&str>) -> ParseErrorRe
         linker = linker.with_file(&get_full_test_path(file));
     }
     let report = linker
-        .link::<RV32>()
+        .link::<RV32>(Default::default())
         .err() // needed because RiscVProgram is not Debug
         .expect("linker did not error when it should have");
     report.report();
@@ -96,7 +96,7 @@ fn test_local_labels() {
 /// Tests linking two files that have no label dependencies.
 fn test_basic_link() {
     let mut program = Linker::with_main(&get_full_test_path("local_labels.s"))
-        .link::<RV32>()
+        .link::<RV32>(Default::default())
         .unwrap();
     program.dump_insts();
     assert_eq!(program.run() as u32, 0xABCD_0123u32);
@@ -107,7 +107,7 @@ fn test_basic_link() {
 fn test_global_link() {
     let mut program = Linker::with_main(&get_full_test_path("global_link_0.s"))
         .with_file(&get_full_test_path("global_link_1.s"))
-        .link::<RV32>()
+        .link::<RV32>(Default::default())
         .unwrap();
     program.dump_insts();
     assert_eq!(program.run(), 0x1234);


### PR DESCRIPTION
This branch adds a memory with a simple linear page table as the default backing memory. More importantly, this adds the infrastructure for user instructions to raise traps, as well as the brk syscall to map pages.

Just a couple more things need to be handled before I can move on to MIPS and building a better frontend:
- Make distinction between normal exits and error exits (perhaps add sim option to make automatically exit quietly when PC reaches end of main file, compared to alternative of having main label jr ra to exit handler)
- Implement a few libc functions that can be linked against by default, e.g. `jal printf` - this also means supporting a flag to set include path