### PR TITLE
Refactor page table

### DIFF
--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -1121,6 +1121,11 @@ mod tests_32 {
         let base_addr = 0xFFFF_0004u32;
         let test_data = 0xABCD_EF01u32;
         state.memory_set_word(ByteAddr32::from(base_addr), DataWord::from(test_data));
+        // Make sure the issue isn't with poking the memory
+        assert_eq!(
+            state.memory_get_word(ByteAddr32::from(base_addr)),
+            DataWord::from(test_data)
+        );
         state.regfile_set(T0, DataWord::from(base_addr));
         // signed loads
         state.apply_inst_test(&Lb::new(T1, T0, DataWord::from(0)));

--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -251,7 +251,9 @@ impl<T: MachineDataWidth> EnvironInst<T> for Ecall {
     }
 
     fn eval(state: &ProgramState<RiscV<T>, T>) -> InstResult<RiscV<T>, T> {
-        state.handle_trap(&TrapKind::Ecall)
+        let mut diffs = state.handle_trap(&TrapKind::Ecall).diffs;
+        diffs.push(UserDiff::pc_p4(&state.user_state).into_state_diff());
+        InstResult::new(diffs)
     }
 }
 

--- a/src/architectures/riscv/isa.rs
+++ b/src/architectures/riscv/isa.rs
@@ -313,10 +313,11 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lb {
     }
 
     fn eval(
-        mem: &dyn Memory<T::ByteAddr>,
+        state: &ProgramState<RiscV<T>, T>,
         addr: T::ByteAddr,
-    ) -> Result<T::RegData, MemFault<T::ByteAddr>> {
-        Ok(<T::RegData>::sign_ext_from_byte(mem.get_byte(addr)?))
+    ) -> Result<MemReadResult<T>, MemFault<T::ByteAddr>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::Byte)?;
+        Ok((<T::RegData>::sign_ext_from_byte(v.into()), inst_result))
     }
 }
 
@@ -331,10 +332,11 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lbu {
     }
 
     fn eval(
-        mem: &dyn Memory<T::ByteAddr>,
+        state: &ProgramState<RiscV<T>, T>,
         addr: T::ByteAddr,
-    ) -> Result<T::RegData, MemFault<T::ByteAddr>> {
-        Ok(<T::RegData>::zero_pad_from_byte(mem.get_byte(addr)?))
+    ) -> Result<MemReadResult<T>, MemFault<T::ByteAddr>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::Byte)?;
+        Ok((<T::RegData>::zero_pad_from_byte(v.into()), inst_result))
     }
 }
 
@@ -349,10 +351,11 @@ impl ITypeLoad<Width64b> for Ld {
     }
 
     fn eval(
-        mem: &dyn Memory<ByteAddr64>,
+        state: &ProgramState<RiscV<Width64b>, Width64b>,
         addr: ByteAddr64,
-    ) -> Result<DataDword, MemFault<ByteAddr64>> {
-        Ok(mem.get_doubleword(addr)?)
+    ) -> Result<MemReadResult<Width64b>, MemFault<ByteAddr64>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::DoubleWord)?;
+        Ok((v.into(), inst_result))
     }
 }
 
@@ -367,10 +370,11 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lh {
     }
 
     fn eval(
-        mem: &dyn Memory<T::ByteAddr>,
+        state: &ProgramState<RiscV<T>, T>,
         addr: T::ByteAddr,
-    ) -> Result<T::RegData, MemFault<T::ByteAddr>> {
-        Ok(<T::RegData>::sign_ext_from_half(mem.get_half(addr)?))
+    ) -> Result<MemReadResult<T>, MemFault<T::ByteAddr>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::Half)?;
+        Ok((<T::RegData>::sign_ext_from_half(v.into()), inst_result))
     }
 }
 
@@ -385,10 +389,11 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lhu {
     }
 
     fn eval(
-        mem: &dyn Memory<T::ByteAddr>,
+        state: &ProgramState<RiscV<T>, T>,
         addr: T::ByteAddr,
-    ) -> Result<T::RegData, MemFault<T::ByteAddr>> {
-        Ok(<T::RegData>::zero_pad_from_half(mem.get_half(addr)?))
+    ) -> Result<MemReadResult<T>, MemFault<T::ByteAddr>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::Half)?;
+        Ok((<T::RegData>::zero_pad_from_half(v.into()), inst_result))
     }
 }
 
@@ -421,10 +426,11 @@ impl<T: MachineDataWidth> ITypeLoad<T> for Lw {
     }
 
     fn eval(
-        mem: &dyn Memory<T::ByteAddr>,
+        state: &ProgramState<RiscV<T>, T>,
         addr: T::ByteAddr,
-    ) -> Result<T::RegData, MemFault<T::ByteAddr>> {
-        Ok(<T::RegData>::sign_ext_from_word(mem.get_word(addr)?))
+    ) -> Result<MemReadResult<T>, MemFault<T::ByteAddr>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::Word)?;
+        Ok((<T::RegData>::sign_ext_from_word(v.into()), inst_result))
     }
 }
 
@@ -439,10 +445,11 @@ impl ITypeLoad<Width64b> for Lwu {
     }
 
     fn eval(
-        mem: &dyn Memory<ByteAddr64>,
+        state: &ProgramState<RiscV<Width64b>, Width64b>,
         addr: ByteAddr64,
-    ) -> Result<DataDword, MemFault<ByteAddr64>> {
-        Ok(DataDword::sign_ext_from_word(mem.get_word(addr)?))
+    ) -> Result<MemReadResult<Width64b>, MemFault<ByteAddr64>> {
+        let (v, inst_result) = state.memory_get(addr, DataWidth::Word)?;
+        Ok((DataDword::sign_ext_from_word(v.into()), inst_result))
     }
 }
 
@@ -489,15 +496,15 @@ impl<T: MachineDataWidth> SType<T> for Sb {
     }
 
     fn eval(
-        state: &UserState<RiscV<T>, T>,
+        state: &ProgramState<RiscV<T>, T>,
         rs1: RiscVRegister,
         rs2: RiscVRegister,
         imm: BitStr32,
     ) -> InstResult<RiscV<T>, T> {
-        let base_addr: T::Signed = state.regfile.read(rs1).into();
+        let base_addr: T::Signed = state.user_state.regfile.read(rs1).into();
         let byte_addr: T::ByteAddr = (base_addr.wrapping_add(&imm.into())).into();
-        let new_byte = state.regfile.read(rs2).get_byte(0);
-        UserDiff::mem_write_op(state, byte_addr, DataEnum::Byte(new_byte)).unwrap()
+        let new_byte = state.user_state.regfile.read(rs2).get_byte(0);
+        UserDiff::mem_write_pc_p4(state, byte_addr, DataEnum::Byte(new_byte)).unwrap()
     }
 }
 
@@ -511,15 +518,15 @@ impl SType<Width64b> for Sd {
     }
 
     fn eval(
-        state: &UserState<RiscV<Width64b>, Width64b>,
+        state: &ProgramState<RiscV<Width64b>, Width64b>,
         rs1: RiscVRegister,
         rs2: RiscVRegister,
         imm: BitStr32,
     ) -> InstResult<RiscV<Width64b>, Width64b> {
-        let base_addr: i64 = state.regfile.read(rs1).into();
+        let base_addr: i64 = state.user_state.regfile.read(rs1).into();
         let byte_addr: ByteAddr64 = (base_addr.wrapping_add(imm.into())).into();
-        let new_dword = state.regfile.read(rs2);
-        UserDiff::mem_write_op(state, byte_addr, DataEnum::DoubleWord(new_dword)).unwrap()
+        let new_dword = state.user_state.regfile.read(rs2);
+        UserDiff::mem_write_pc_p4(state, byte_addr, DataEnum::DoubleWord(new_dword)).unwrap()
     }
 }
 
@@ -533,17 +540,17 @@ impl<T: MachineDataWidth> SType<T> for Sh {
     }
 
     fn eval(
-        state: &UserState<RiscV<T>, T>,
+        state: &ProgramState<RiscV<T>, T>,
         rs1: RiscVRegister,
         rs2: RiscVRegister,
         imm: BitStr32,
     ) -> InstResult<RiscV<T>, T> {
-        let base_addr: T::Signed = state.regfile.read(rs1).into();
+        let base_addr: T::Signed = state.user_state.regfile.read(rs1).into();
         let byte_addr: T::ByteAddr = (base_addr.wrapping_add(&imm.into())).into();
-        let lower_byte: u8 = state.regfile.read(rs2).get_byte(0).into();
-        let upper_byte: u8 = state.regfile.read(rs2).get_byte(1).into();
+        let lower_byte: u8 = state.user_state.regfile.read(rs2).get_byte(0).into();
+        let upper_byte: u8 = state.user_state.regfile.read(rs2).get_byte(1).into();
         let full: u16 = ((upper_byte as u16) << 8) | (lower_byte as u16);
-        UserDiff::mem_write_op(state, byte_addr, DataEnum::Half(full.into())).unwrap()
+        UserDiff::mem_write_pc_p4(state, byte_addr, DataEnum::Half(full.into())).unwrap()
     }
 }
 
@@ -591,17 +598,17 @@ impl<T: MachineDataWidth> SType<T> for Sw {
     }
 
     fn eval(
-        state: &UserState<RiscV<T>, T>,
+        state: &ProgramState<RiscV<T>, T>,
         rs1: RiscVRegister,
         rs2: RiscVRegister,
         imm: BitStr32,
     ) -> InstResult<RiscV<T>, T> {
-        let base_addr: T::Signed = state.regfile.read(rs1).into();
+        let base_addr: T::Signed = state.user_state.regfile.read(rs1).into();
         let byte_addr: T::ByteAddr = (base_addr.wrapping_add(&imm.into())).into();
-        UserDiff::mem_write_op(
+        UserDiff::mem_write_pc_p4(
             state,
             byte_addr,
-            DataEnum::Word(state.regfile.read(rs2).get_lower_word()),
+            DataEnum::Word(state.user_state.regfile.read(rs2).get_lower_word()),
         )
         .unwrap()
     }

--- a/src/architectures/riscv/program.rs
+++ b/src/architectures/riscv/program.rs
@@ -29,6 +29,10 @@ impl ProgramBehavior<RiscV<Width32b>, Width32b> for RiscVProgramBehavior<Width32
     fn data_start() -> ByteAddr32 {
         0x2000_0000.into()
     }
+
+    fn heap_start() -> ByteAddr32 {
+        0x4000_0000.into()
+    }
 }
 
 impl ProgramBehavior<RiscV<Width64b>, Width64b> for RiscVProgramBehavior<Width64b> {
@@ -50,6 +54,10 @@ impl ProgramBehavior<RiscV<Width64b>, Width64b> for RiscVProgramBehavior<Width64
 
     fn data_start() -> ByteAddr64 {
         0x2000_0000_0000_0000u64.into()
+    }
+
+    fn heap_start() -> ByteAddr64 {
+        0x4000_0000_0000_0000u64.into()
     }
 }
 

--- a/src/assembler/assembler_impl.rs
+++ b/src/assembler/assembler_impl.rs
@@ -381,6 +381,8 @@ impl<A: Architecture> UnlinkedProgram<A> {
             Ok(Program::<A>::new(
                 insts,
                 self.sections,
+                config.mem_config.phys_pn_bits,
+                config.mem_config.pg_ofs_bits,
                 config.mem_config.build_mem(),
             ))
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,17 +33,18 @@ impl Default for MachineConfig {
 /// TODO add options for alignment and default value
 #[derive(Debug)]
 pub struct MemConfig {
+    pub phys_pn_bits: usize,
+    pub pg_ofs_bits: usize,
     pub kind: PtKind,
 }
 
 impl Default for MemConfig {
     fn default() -> Self {
         MemConfig {
+            phys_pn_bits: 10,
+            pg_ofs_bits: 12,
             // 4 KiB page size, 4 MiB physical memory
-            kind: PtKind::FifoLinearPaged {
-                phys_pn_bits: 10,
-                pg_ofs_bits: 12,
-            },
+            kind: PtKind::FifoLinearPaged,
         }
     }
 }
@@ -54,10 +55,9 @@ impl MemConfig {
         let kind = self.kind;
         match kind {
             PtKind::AllMapped => Box::new(AllMappedPt::<T>::new()),
-            PtKind::FifoLinearPaged {
-                phys_pn_bits,
-                pg_ofs_bits,
-            } => Box::new(FifoLinearPt::<T>::new(phys_pn_bits, pg_ofs_bits)),
+            PtKind::FifoLinearPaged => {
+                Box::new(FifoLinearPt::<T>::new(self.phys_pn_bits, self.pg_ofs_bits))
+            }
         }
     }
 }
@@ -65,8 +65,5 @@ impl MemConfig {
 #[derive(Copy, Clone, Debug)]
 pub enum PtKind {
     AllMapped,
-    FifoLinearPaged {
-        phys_pn_bits: usize,
-        pg_ofs_bits: usize,
-    },
+    FifoLinearPaged,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,16 +33,16 @@ impl Default for MachineConfig {
 /// TODO add options for alignment and default value
 #[derive(Debug)]
 pub struct MemConfig {
-    pub kind: MemKind,
+    pub kind: PtKind,
 }
 
 impl Default for MemConfig {
     fn default() -> Self {
         MemConfig {
             // 4 KiB page size, 4 MiB physical memory
-            kind: MemKind::LinearPaged {
-                phys_addr_len: 22,
-                page_offs_len: 12,
+            kind: PtKind::FifoLinearPaged {
+                phys_pn_bits: 10,
+                pg_ofs_bits: 12,
             },
         }
     }
@@ -53,21 +53,20 @@ impl MemConfig {
         use crate::program_state::*;
         let kind = self.kind;
         match kind {
-            MemKind::Simple => Box::new(AllMappedPt::<T>::new()),
-            _ => unimplemented!()
-            // MemKind::LinearPaged {
-            //     phys_addr_len,
-            //     page_offs_len,
-            // } => Box::new(LinearPagedMemory::<T>::new(phys_addr_len, page_offs_len)),
+            PtKind::AllMapped => Box::new(AllMappedPt::<T>::new()),
+            PtKind::FifoLinearPaged {
+                phys_pn_bits,
+                pg_ofs_bits,
+            } => Box::new(FifoLinearPt::<T>::new(phys_pn_bits, pg_ofs_bits)),
         }
     }
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum MemKind {
-    Simple,
-    LinearPaged {
-        phys_addr_len: usize,
-        page_offs_len: usize,
+pub enum PtKind {
+    AllMapped,
+    FifoLinearPaged {
+        phys_pn_bits: usize,
+        pg_ofs_bits: usize,
     },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,15 +49,16 @@ impl Default for MemConfig {
 }
 
 impl MemConfig {
-    pub fn build_mem<T: ByteAddress>(&self) -> Box<dyn Memory<T>> {
+    pub fn build_mem<T: ByteAddress>(&self) -> Box<dyn PageTable<T>> {
         use crate::program_state::*;
         let kind = self.kind;
         match kind {
-            MemKind::Simple => Box::new(SimpleMemory::<T>::new()),
-            MemKind::LinearPaged {
-                phys_addr_len,
-                page_offs_len,
-            } => Box::new(LinearPagedMemory::<T>::new(phys_addr_len, page_offs_len)),
+            MemKind::Simple => Box::new(AllMappedPt::<T>::new()),
+            _ => unimplemented!()
+            // MemKind::LinearPaged {
+            //     phys_addr_len,
+            //     page_offs_len,
+            // } => Box::new(LinearPagedMemory::<T>::new(phys_addr_len, page_offs_len)),
         }
     }
 }

--- a/src/program_state/bitmap.rs
+++ b/src/program_state/bitmap.rs
@@ -1,0 +1,94 @@
+/// A simple implementation of an integer-backed bitmap, for use in representing free lists for
+/// disk blocks or memory sectors.
+///
+/// The map itself is backed by a vector of u64s that are preallocated to 0.
+pub struct Bitmap {
+    bit_cnt: usize,
+    bits: Vec<u64>,
+}
+
+impl Bitmap {
+    /// Constructs a new bitmap with bit_cnt entries.
+    pub fn new(bit_cnt: usize) -> Bitmap {
+        // if we need 0 bits then we allocate 0 ints, but if we need 1 byte we need to allocate
+        // 1 int even though 1 / 64 = 0
+        let round_up = bit_cnt % 64 != 0;
+        Bitmap {
+            bit_cnt,
+            bits: vec![0; bit_cnt / 64 + (if round_up { 1 } else { 0 })],
+        }
+    }
+
+    fn bounds_check(&self, idx: usize) {
+        if idx >= self.bit_cnt {
+            panic!(
+                "Attempted to access index {} for bitmap of size {}",
+                idx, self.bit_cnt
+            )
+        }
+    }
+
+    /// Reads an entry in the bitmap. Panics if the index is out of bounds.
+    pub fn read(&self, idx: usize) -> bool {
+        self.bounds_check(idx);
+        let n = self.bits[idx / 64];
+        let bit_idx = idx % 64;
+        ((n >> bit_idx) & 0b1) != 0
+    }
+
+    /// Flips an entry in the bitmap. Panics if the index is out of bounds.
+    pub fn flip(&mut self, idx: usize) {
+        self.bounds_check(idx);
+        // to flip one bit, XOR the entry with a mask of all 0s
+        // except at the desired index
+        let bit_idx = idx % 64;
+        let mask = 1 << bit_idx;
+        let k = idx / 64;
+        self.bits[k] = self.bits[k] ^ mask;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Bitmap;
+
+    /// Tests a bitmap backed by only a single integer.
+    #[test]
+    fn test_bitmap_small() {
+        let mut bm = Bitmap::new(64);
+        bm.flip(0);
+        bm.flip(31);
+        // extra checks ensure no off-by-one errors
+        assert_eq!(bm.read(0), true);
+        assert_eq!(bm.read(1), false);
+        assert_eq!(bm.read(30), false);
+        assert_eq!(bm.read(31), true);
+        assert_eq!(bm.read(32), false);
+        bm.flip(0);
+        assert_eq!(bm.read(0), false);
+        assert_eq!(bm.read(1), false);
+    }
+
+    /// Tests a bitmap backed by several integers.
+    #[test]
+    fn test_bitmap_several() {
+        let mut bm = Bitmap::new(256);
+        bm.flip(0);
+        bm.flip(31);
+        bm.flip(142);
+        bm.flip(255);
+        // extra checks ensure no off-by-one errors
+        assert_eq!(bm.read(0), true);
+        assert_eq!(bm.read(31), true);
+        assert_eq!(bm.read(142), true);
+        assert_eq!(bm.read(255), true);
+        bm.flip(142);
+        assert_eq!(bm.read(142), false);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bitmap_cap() {
+        Bitmap::new(128).read(128);
+    }
+}

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -113,6 +113,17 @@ pub enum DataWidth {
     DoubleWord,
 }
 
+impl DataWidth {
+    pub fn zero(self) -> DataEnum {
+        match self {
+            DataWidth::Byte => DataEnum::Byte(0u8.into()),
+            DataWidth::Half => DataEnum::Half(0u16.into()),
+            DataWidth::Word => DataEnum::Word(0u32.into()),
+            DataWidth::DoubleWord => DataEnum::DoubleWord(0u64.into()),
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum DataEnum {
     Byte(DataByte),
@@ -441,6 +452,12 @@ impl From<BitStr32> for DataWord {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct DataHalf {
     value: u16,
+}
+
+impl DataHalf {
+    pub const fn zero() -> DataHalf {
+        DataHalf { value: 0 }
+    }
 }
 
 impl Data for DataHalf {

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -132,6 +132,42 @@ impl DataEnum {
     }
 }
 
+impl From<DataEnum> for DataByte {
+    fn from(value: DataEnum) -> DataByte {
+        match value {
+            DataEnum::Byte(b) => b,
+            _ => panic!("DataByte was coerced from DataEnum of wrong width"),
+        }
+    }
+}
+
+impl From<DataEnum> for DataHalf {
+    fn from(value: DataEnum) -> DataHalf {
+        match value {
+            DataEnum::Half(h) => h,
+            _ => panic!("DataHalf was coerced from DataEnum of wrong width"),
+        }
+    }
+}
+
+impl From<DataEnum> for DataWord {
+    fn from(value: DataEnum) -> DataWord {
+        match value {
+            DataEnum::Word(w) => w,
+            _ => panic!("DataWord was coerced from DataEnum of wrong width"),
+        }
+    }
+}
+
+impl From<DataEnum> for DataDword {
+    fn from(value: DataEnum) -> DataDword {
+        match value {
+            DataEnum::DoubleWord(d) => d,
+            _ => panic!("DataDword was coerced from DataEnum of wrong width"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum DataEnumDiff {
     Byte { old: DataByte, new: DataByte },
@@ -141,7 +177,7 @@ pub enum DataEnumDiff {
 }
 
 impl DataEnumDiff {
-    pub fn old(self) -> DataEnum {
+    pub fn old_val(self) -> DataEnum {
         use DataEnumDiff::*;
         match self {
             Byte { old, .. } => DataEnum::Byte(old),
@@ -151,7 +187,7 @@ impl DataEnumDiff {
         }
     }
 
-    pub fn new(self) -> DataEnum {
+    pub fn new_val(self) -> DataEnum {
         use DataEnumDiff::*;
         match self {
             Byte { new, .. } => DataEnum::Byte(new),

--- a/src/program_state/datatypes.rs
+++ b/src/program_state/datatypes.rs
@@ -132,6 +132,36 @@ impl DataEnum {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum DataEnumDiff {
+    Byte { old: DataByte, new: DataByte },
+    Half { old: DataHalf, new: DataHalf },
+    Word { old: DataWord, new: DataWord },
+    DoubleWord { old: DataDword, new: DataDword },
+}
+
+impl DataEnumDiff {
+    pub fn old(self) -> DataEnum {
+        use DataEnumDiff::*;
+        match self {
+            Byte { old, .. } => DataEnum::Byte(old),
+            Half { old, .. } => DataEnum::Half(old),
+            Word { old, .. } => DataEnum::Word(old),
+            DoubleWord { old, .. } => DataEnum::DoubleWord(old),
+        }
+    }
+
+    pub fn new(self) -> DataEnum {
+        use DataEnumDiff::*;
+        match self {
+            Byte { new, .. } => DataEnum::Byte(new),
+            Half { new, .. } => DataEnum::Half(new),
+            Word { new, .. } => DataEnum::Word(new),
+            DoubleWord { new, .. } => DataEnum::DoubleWord(new),
+        }
+    }
+}
+
 /// Marker trait for different datatypes.
 pub trait Data: Copy + Clone + PartialEq {
     fn kind(self) -> DataEnum;

--- a/src/program_state/memory.rs
+++ b/src/program_state/memory.rs
@@ -28,6 +28,7 @@ impl Default for PtEntry {
 }
 
 /// Represents an operation that updates the page table.
+#[derive(Debug)]
 pub enum PtUpdate {
     /// An update to an entry in the page table.
     Entry {
@@ -351,6 +352,7 @@ impl<T: ByteAddress> PageTable<T> for FifoLinearPt<T> {
             old: old_pte,
             new: PtEntry { valid: true, ppn },
         });
+        println!("Mapping entry for VPN {:X} to PPN {}", vpn, ppn);
         Ok(diffs)
     }
 
@@ -380,6 +382,7 @@ impl<T: ByteAddress> PageTable<T> for FifoLinearPt<T> {
             if let Some(pte) = self.page_table.get(&vpn) {
                 if pte.valid {
                     let offs = self.get_page_offs(vaddr);
+                    println!("Found entry for VPN {:0X} (PPN {})", vpn, pte.ppn);
                     return Ok(PtLookupData {
                         diffs: vec![],
                         ppn: pte.ppn,

--- a/src/program_state/mod.rs
+++ b/src/program_state/mod.rs
@@ -1,3 +1,4 @@
+mod bitmap;
 mod datatypes;
 mod memory;
 mod phys;

--- a/src/program_state/phys.rs
+++ b/src/program_state/phys.rs
@@ -1,6 +1,184 @@
 //! Represents the physical devices accessible to the machine, such as the disk and RAM.
 
-#[allow(dead_code)]
+use super::datatypes::*;
+use std::collections::HashMap;
+
+/// Indexes into physical memory. Constrained by the number of pages.
+pub type PhysPn = usize;
+/// Indexes into a page. Constrained by the size of the page.
+pub type PageOffs = usize;
+
 pub struct PhysState {
-    // TODO
+    /// Physical memory, indexed by physical page numbers.
+    pub phys_mem: Vec<MemPage>,
+}
+
+pub enum PhysDiff {
+    /// Updates the data stored at the specified location. Assumes the ppn exists.
+    MemSet {
+        ppn: PhysPn,
+        offs: PageOffs,
+        diff: DataEnumDiff,
+    },
+}
+
+impl PhysState {
+    pub fn apply_diff(&mut self, diff: &PhysDiff) {
+        match diff {
+            PhysDiff::MemSet { ppn, offs, diff } => self.phys_mem[*ppn].set(*offs, diff.old()),
+        }
+    }
+
+    pub fn revert_diff(&mut self, diff: &PhysDiff) {
+        match diff {
+            PhysDiff::MemSet { ppn, offs, diff } => self.phys_mem[*ppn].set(*offs, diff.new()),
+        }
+    }
+}
+
+/// Represents the order that bytes in a word are stored.
+/// See https://en.wikipedia.org/wiki/Endianness for more information.
+pub enum Endianness {
+    Big,
+    Little,
+}
+
+/// Represents a page of memory.
+/// TODO implement default value (currently 0)
+pub struct MemPage {
+    endianness: Endianness,
+    /// The address of the last addressable byte in the page. We can't just use the size of the page
+    /// in case it's set to 2^64, in which case it would overflow usize on 64-bit systems.
+    largest_idx: usize,
+    /// To ensure the simulator doesn't waste space allocating the full size of the page,
+    /// this backing store allocates bytes lazily.
+    ///
+    /// Eventually this should be modified for perf optimizations.
+    backing: HashMap<PageOffs, u8>,
+}
+
+impl Default for MemPage {
+    /// Produces a little-endian page of 4KiB.
+    fn default() -> Self {
+        MemPage::new(Endianness::Little, 12)
+    }
+}
+
+impl MemPage {
+    fn new(endianness: Endianness, ofs_bits: usize) -> MemPage {
+        MemPage {
+            endianness,
+            largest_idx: (1usize).wrapping_shl(ofs_bits as u32) - 1,
+            backing: HashMap::new(),
+        }
+    }
+
+    fn set_byte(&mut self, offs: PageOffs, value: DataByte) {
+        assert!(offs <= self.largest_idx);
+        self.backing.insert(offs, value.into());
+    }
+
+    fn get_byte(&self, offs: PageOffs) -> DataByte {
+        assert!(offs <= self.largest_idx);
+        (*self.backing.get(&offs).unwrap_or(&0)).into()
+    }
+
+    fn set_half(&mut self, offs: PageOffs, value: DataHalf) {
+        let half: u16 = value.into();
+        match self.endianness {
+            Endianness::Big => {
+                self.set_byte(offs, ((half >> 8) as u8).into());
+                self.set_byte(offs + 1, (half as u8).into());
+            }
+            Endianness::Little => {
+                self.set_byte(offs, (half as u8).into());
+                self.set_byte(offs + 1, ((half >> 8) as u8).into());
+            }
+        }
+    }
+
+    fn get_half(&self, offs: PageOffs) -> DataHalf {
+        let lower: u8 = self.get_byte(offs).into();
+        let upper: u8 = self.get_byte(offs + 1).into();
+        match self.endianness {
+            Endianness::Big => DataHalf::from(((lower as u16) << 8) | (upper as u16)),
+            Endianness::Little => DataHalf::from(((upper as u16) << 8) | (lower as u16)),
+        }
+    }
+
+    fn set_word(&mut self, offs: PageOffs, value: DataWord) {
+        let word: u32 = value.into();
+        match self.endianness {
+            Endianness::Big => {
+                self.set_half(offs, ((word >> 16) as u16).into());
+                self.set_half(offs + 2, (word as u16).into());
+            }
+            Endianness::Little => {
+                self.set_half(offs, (word as u16).into());
+                self.set_half(offs + 2, ((word >> 16) as u16).into());
+            }
+        }
+    }
+
+    fn get_word(&self, offs: PageOffs) -> DataWord {
+        let lower: u16 = self.get_half(offs).into();
+        let upper: u16 = self.get_half(offs + 2).into();
+        match self.endianness {
+            Endianness::Big => DataWord::from(((lower as u32) << 16) | (upper as u32)),
+            Endianness::Little => DataWord::from(((upper as u32) << 16) | (lower as u32)),
+        }
+    }
+
+    /// Note: if you're invoking this function, duna assumes that your word size is 64-bit, meaning
+    /// endianness will apply to the whole 64 bits rather than to each 32-bit chunk.
+    fn set_doubleword(&mut self, offs: PageOffs, value: DataDword) {
+        let dword: u64 = value.into();
+        match self.endianness {
+            Endianness::Big => {
+                self.set_word(offs, ((dword >> 32) as u32).into());
+                self.set_word(offs + 4, (dword as u32).into());
+            }
+            Endianness::Little => {
+                self.set_word(offs, (dword as u32).into());
+                self.set_word(offs + 4, ((dword >> 32) as u32).into());
+            }
+        }
+    }
+
+    /// Note: if you're invoking this function, duna assumes that your word size is 64-bit, meaning
+    /// endianness will apply to the whole 64 bits rather than to each 32-bit chunk.
+    fn get_doubleword(&self, offs: PageOffs) -> DataDword {
+        let lower: u32 = self.get_word(offs).into();
+        let upper: u32 = self.get_word(offs + 4).into();
+        match self.endianness {
+            Endianness::Big => DataDword::from(((lower as u64) << 32) | (upper as u64)),
+            Endianness::Little => DataDword::from(((upper as u64) << 32) | (lower as u64)),
+        }
+    }
+
+    fn set(&mut self, offs: PageOffs, value: DataEnum) {
+        match value {
+            DataEnum::Byte(v) => self.set_byte(offs, v),
+            DataEnum::Half(v) => self.set_half(offs, v),
+            DataEnum::Word(v) => self.set_word(offs, v),
+            DataEnum::DoubleWord(v) => self.set_doubleword(offs, v),
+        }
+    }
+
+    fn get(&self, offs: PageOffs, w: DataWidth) -> DataEnum {
+        match w {
+            DataWidth::Byte => DataEnum::Byte(self.get_byte(offs)),
+            DataWidth::Half => DataEnum::Half(self.get_half(offs)),
+            DataWidth::Word => DataEnum::Word(self.get_word(offs)),
+            DataWidth::DoubleWord => DataEnum::DoubleWord(self.get_doubleword(offs)),
+        }
+    }
+}
+
+/// Represents a physical memory device chunked into pages.
+/// Each page is represented sparsely in memory by a map.
+pub struct PagedMem {
+    pg_count: usize,
+    pg_size: usize,
+    pages: HashMap<PhysPn, MemPage>,
 }

--- a/src/program_state/phys.rs
+++ b/src/program_state/phys.rs
@@ -101,7 +101,12 @@ impl PhysState {
         offs: PageOffs,
         width: DataWidth,
     ) -> Result<DataEnum, ()> {
-        assert!(ppn < self.pg_count);
+        assert!(
+            ppn < self.pg_count,
+            "PPN was {} but max page count was {}",
+            ppn,
+            self.pg_count
+        );
         self.check_alignment(offs, width)?;
         Ok(self
             .phys_mem
@@ -112,7 +117,12 @@ impl PhysState {
 
     // should really find a way type parameterize instead of using an enum
     pub fn memory_set(&self, ppn: PhysPn, offs: PageOffs, data: DataEnum) -> Result<PhysDiff, ()> {
-        assert!(ppn < self.pg_count);
+        assert!(
+            ppn < self.pg_count,
+            "PPN was {} but max page count was {}",
+            ppn,
+            self.pg_count
+        );
         self.check_alignment(offs, data.width())?;
         use DataEnumDiff::*;
         Ok(PhysDiff::MemSet {

--- a/src/program_state/phys.rs
+++ b/src/program_state/phys.rs
@@ -136,10 +136,6 @@ impl MemPage {
         } else {
             (1usize).wrapping_shl(ofs_bits as u32) - 1
         };
-        println!(
-            "INIT: ofs_bits {:?}, largest_idx {:?}",
-            ofs_bits, largest_idx
-        );
         MemPage {
             endianness,
             largest_idx,
@@ -153,7 +149,6 @@ impl MemPage {
     }
 
     pub(crate) fn get_byte(&self, offs: PageOffs) -> DataByte {
-        println!("offs: {:?}, largest: {:?}", offs, self.largest_idx);
         assert!(offs <= self.largest_idx);
         (*self.backing.get(&offs).unwrap_or(&0)).into()
     }

--- a/src/program_state/priv_s.rs
+++ b/src/program_state/priv_s.rs
@@ -93,7 +93,7 @@ pub enum PrivDiff<T: MachineDataWidth> {
         fd: T::RegData,
         data: Vec<u8>,
     },
-    PtUpdate(PteUpdate),
+    PtUpdate(PtUpdate),
 }
 
 impl<T: MachineDataWidth> PrivDiff<T> {

--- a/src/program_state/program.rs
+++ b/src/program_state/program.rs
@@ -46,7 +46,7 @@ impl<A: Architecture> Program<A> {
     pub fn new(
         insts: Vec<<A::Family as ArchFamily<A::DataWidth>>::Instruction>,
         sections: SectionStore,
-        mut memory: Box<dyn Memory<<A::DataWidth as MachineDataWidth>::ByteAddr>>,
+        mut memory: Box<dyn PageTable<<A::DataWidth as MachineDataWidth>::ByteAddr>>,
     ) -> Self {
         let text_start =
             <A::ProgramBehavior as ProgramBehavior<A::Family, A::DataWidth>>::text_start();
@@ -213,13 +213,13 @@ impl<A: Architecture> ProgramExecutor<A> {
 }
 
 pub struct ProgramState<F: ArchFamily<T>, T: MachineDataWidth> {
-    pub(crate) priv_state: PrivState,
+    pub(crate) priv_state: PrivState<T>,
     pub(crate) user_state: UserState<F, T>,
 }
 
 impl<F: ArchFamily<T>, T: MachineDataWidth> Default for ProgramState<F, T> {
     fn default() -> Self {
-        ProgramState::new(Box::new(SimpleMemory::new()))
+        ProgramState::new(Box::new(AllMappedPt::new()))
     }
 }
 
@@ -360,7 +360,7 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> ProgramState<F, T> {
         panic!("Unknown syscall")
     }
 
-    pub fn new(memory: Box<dyn Memory<T::ByteAddr>>) -> ProgramState<F, T> {
+    pub fn new(memory: Box<dyn PageTable<T::ByteAddr>>) -> ProgramState<F, T> {
         ProgramState {
             priv_state: PrivState::new(),
             user_state: UserState::new(memory),

--- a/src/program_state/program.rs
+++ b/src/program_state/program.rs
@@ -275,14 +275,14 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> ProgramState<F, T> {
         width: DataWidth,
     ) -> Result<(DataEnum, InstResult<F, T>), MemFault<T::ByteAddr>> {
         // TODO how do we handle lookups spanning multiple pages?
-        let PteLookupData {
+        let PtLookupData {
             diffs: pt_diffs,
             ppn,
             offs,
         } = self.priv_state.page_table.lookup_page(vaddr)?;
         let diffs: Vec<StateDiff<F, T>> = pt_diffs
             .into_iter()
-            .map(PteUpdate::into_state_diff)
+            .map(PtUpdate::into_state_diff)
             .collect();
         Ok((
             self.phys_state.memory_get(ppn, offs, width),
@@ -298,14 +298,14 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> ProgramState<F, T> {
         data: DataEnum,
     ) -> Result<InstResult<F, T>, MemFault<T::ByteAddr>> {
         // TODO how do we handle lookups spanning multiple pages?
-        let PteLookupData {
+        let PtLookupData {
             diffs: pt_diffs,
             ppn,
             offs,
         } = self.priv_state.page_table.lookup_page(vaddr)?;
         let mut diffs: Vec<StateDiff<F, T>> = pt_diffs
             .into_iter()
-            .map(PteUpdate::into_state_diff)
+            .map(PtUpdate::into_state_diff)
             .collect();
         diffs.push(
             self.phys_state

--- a/src/program_state/program.rs
+++ b/src/program_state/program.rs
@@ -443,9 +443,8 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> ProgramState<F, T> {
 
     /// Attempts to move the "program break" up to the indicated location.
     /// For us, this means the OS will attempt to page in memory up to the designated address.
-    /// TODO unmap pages if brk goes down, and allocate multiple pages
-    /// TODO change type signature to be increment rather than address, which is what
-    /// actual brk does. also check edge case where brk lands on page boundary
+    /// TODO unmap pages if brk goes down, and allocate multiple pages, also check edge case where
+    /// brk lands on page boundary
     /// * addr - the address whose page should be mapped afterwards
     fn syscall_brk(&self, addr: T::ByteAddr) -> InstResult<F, T> {
         let old_brk: T::RegData = self.priv_state.brk.into();
@@ -463,7 +462,14 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> ProgramState<F, T> {
                 }
                 .into_state_diff(),
             );
-            diffs.push(UserDiff::reg_update(&self.user_state, ret_reg, old_brk).into_state_diff());
+            diffs.push(
+                UserDiff::reg_update(
+                    &self.user_state,
+                    ret_reg,
+                    <T as MachineDataWidth>::sgn_zero().into(),
+                )
+                .into_state_diff(),
+            );
             // Update brk, return the old value, and propagate PT state changes
             InstResult::new(diffs)
         } else if let Ok(updates) = self.priv_state.page_table.map_page(addr) {
@@ -476,7 +482,14 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> ProgramState<F, T> {
                 }
                 .into_state_diff(),
             );
-            diffs.push(UserDiff::reg_update(&self.user_state, ret_reg, old_brk).into_state_diff());
+            diffs.push(
+                UserDiff::reg_update(
+                    &self.user_state,
+                    ret_reg,
+                    <T as MachineDataWidth>::sgn_zero().into(),
+                )
+                .into_state_diff(),
+            );
             InstResult::new(diffs)
         } else {
             UserDiff::reg_update(

--- a/src/program_state/user.rs
+++ b/src/program_state/user.rs
@@ -103,6 +103,16 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> UserDiff<F, T> {
         .into_state_diff()])
     }
 
+    pub fn reg_update(state: &UserState<F, T>, reg: F::Register, rd_val: T::RegData) -> Self {
+        UserDiff::RegDiff {
+            reg,
+            change: RegDataChange {
+                old_value: state.regfile.read(reg),
+                new_value: rd_val,
+            },
+        }
+    }
+
     pub fn reg_write_op(
         state: &UserState<F, T>,
         new_pc: T::ByteAddr,

--- a/src/program_state/user.rs
+++ b/src/program_state/user.rs
@@ -16,7 +16,6 @@ pub struct UserState<F: ArchFamily<T>, T: MachineDataWidth> {
     pub regfile: RegFile<F::Register, T>,
 }
 
-#[cfg(test)]
 impl<F: ArchFamily<T>, T: MachineDataWidth> Default for UserState<F, T> {
     fn default() -> Self {
         UserState::new()
@@ -138,17 +137,14 @@ impl<F: ArchFamily<T>, T: MachineDataWidth> UserDiff<F, T> {
         UserDiff::reg_write_op(state, state.pc.plus_4(), reg, val)
     }
 
-    /// Performs a memory write operation.
-    /// This may trap to the OS in the event of exceptional events like a page fault.
-    pub fn mem_write_op(
+    pub fn mem_write_pc_p4(
         state: &ProgramState<F, T>,
         addr: T::ByteAddr,
         val: DataEnum,
     ) -> Result<InstResult<F, T>, MemFault<T::ByteAddr>> {
-        Ok(InstResult::new(vec![
-            // TODO
-            UserDiff::pc_p4(state).into_state_diff(),
-        ]))
+        let mut diffs = state.memory_set(addr, val)?.diffs;
+        diffs.push(UserDiff::pc_p4(&state.user_state).into_state_diff());
+        Ok(InstResult::new(diffs))
     }
 }
 

--- a/tests/rv32.rs
+++ b/tests/rv32.rs
@@ -196,6 +196,7 @@ fn test_jump_to_la() {
 }
 
 /// Tests that data directives preserve appropriate alignment, even across files.
+/// Assumes the data segment starts at 0x2000_0000.
 #[test]
 fn test_aligned_directive_labels() {
     let mut program = Linker::with_main(&get_full_test_path("aligned_directive_labels_0.s"))
@@ -204,15 +205,15 @@ fn test_aligned_directive_labels() {
         .unwrap();
     program.dump_insts();
     println!(
-        "at 18 , i found {:#X}",
+        "at 18, I found {:#X}",
         u32::from(program.state.memory_inspect_word(0x2000_0018.into()))
     );
     println!(
-        "at 14 , i found {:#X}",
+        "at 14, I found {:#X}",
         u32::from(program.state.memory_inspect_word(0x2000_0014.into()))
     );
     println!(
-        "at 0x10 , i found {:#X}",
+        "at 0x10, I found {:#X}",
         u32::from(program.state.memory_inspect_word(0x2000_0010.into()))
     );
     program.run();

--- a/tests/rv32.rs
+++ b/tests/rv32.rs
@@ -205,15 +205,15 @@ fn test_aligned_directive_labels() {
     program.dump_insts();
     println!(
         "at 18 , i found {:#X}",
-        u32::from(program.state.memory_get_word(0x2000_0018.into()))
+        u32::from(program.state.memory_inspect_word(0x2000_0018.into()))
     );
     println!(
         "at 14 , i found {:#X}",
-        u32::from(program.state.memory_get_word(0x2000_0014.into()))
+        u32::from(program.state.memory_inspect_word(0x2000_0014.into()))
     );
     println!(
         "at 0x10 , i found {:#X}",
-        u32::from(program.state.memory_get_word(0x2000_0010.into()))
+        u32::from(program.state.memory_inspect_word(0x2000_0010.into()))
     );
     program.run();
     use RiscVRegister::*;

--- a/tests/rv32.rs
+++ b/tests/rv32.rs
@@ -171,7 +171,7 @@ fn test_bad_unaligned_word() {
 }
 
 /// Tests the brk syscall, which should map a page.
-// #[test]
+#[test]
 fn test_brk_single_page() {
     check_a0_at_end("brk_single_page.s", 0xDEAD_BEEFu32);
 }


### PR DESCRIPTION
Mostly refactors the page table flow of control: all PT updates are now also diffs that need to be applied by the executor to take effect. Some jank stuff that still needs to be fixed:
- Physical memory is passed as an argument to apply_diff
- heap_start is needed as an argument to program state constructor
- FIFO is definitely implemented incorrectly